### PR TITLE
add support for the Weekend crossword

### DIFF
--- a/public/status-check.html
+++ b/public/status-check.html
@@ -21,6 +21,7 @@ along the way and doesn't make it into CAPI, the information below should be use
     <option value="quiptic">quiptic</option>
     <option value="everyman">everyman</option>
     <option value="prize">prize</option>
+    <option value="weekend">weekend</option>
 </select>
 
 <input type="number" name="id" id="id-input"/>

--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -19,6 +19,10 @@ case object Quiptic extends CrosswordType {
   val name = "quiptic"
   def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(877, new LocalDate(2016, 9, 5), 1)(date)
 }
+case object Weekend extends CrosswordType {
+  val name = "weekend"
+  def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(328, new LocalDate(2017, 4, 15), 6)(date)
+}
 case object Prize extends CrosswordType {
   val name = "prize"
   def getNo(date: LocalDate) = {
@@ -59,7 +63,7 @@ case object Cryptic extends CrosswordType {
 }
 
 object CrosswordTypeHelpers {
-  val allTypes = List(Speedy, Quick, Cryptic, Everyman, Quiptic, Prize)
+  val allTypes = List(Speedy, Quick, Cryptic, Everyman, Quiptic, Prize, Weekend)
   def getNoForWeeklyXword(baseNo: Int, basePubDate: LocalDate, publicationDayOfWeek: Int)(date: LocalDate): Option[Int] = {
 
     if (publicationDayOfWeek != date.getDayOfWeek) None


### PR DESCRIPTION
In order to support the new Weekend crossword type, we need to:

+ Add the type to the picker in the UI
+ Create the logic which is used to calculate the number from the date (by counting weekly from a known starting point).
+ Include this weekend type in the list of all crossword types that are checked.

This PR was created by pairing with @philmcmahon .