### PR TITLE
use x-api-key header to set API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The lambda also has an endpoint which checks the next N days for crosswords whic
  
 Example API usage:
 
-`https://<cloudfront-url>/PROD/get-status?type=quiptic&id=896&api-key=<get from aws console>`
+`https://<cloudfront-url>/PROD/get-status?type=quiptic&id=896`
 
 Finally, there is also a function which will check a specific date for crosswords due to be published then, and list them
 this hasn't been wired up to API gateway yet, so the best way to try it is to run the function locally or send a test

--- a/public/status-check.js
+++ b/public/status-check.js
@@ -33,9 +33,10 @@ function getCrosswordStatus(id, type) {
         crossOrigin: true,
         headers: {
             'Accept': 'application/json',
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'x-api-key': apiKey
         },
-        data: [ { name: 'type', value: type }, { name: 'id', value: id }, { name: 'api-key', value: apiKey} ]
+        data: [ { name: 'type', value: type }, { name: 'id', value: id } ]
     }, function(resp) {
         console.log(resp);
         $('#crossword-status-info').append(statusTableTemplate({status: resp, cwordId: id, type: type}));


### PR DESCRIPTION
API keys are required now (thanks to a redeploy of the API) - This ensures the correct header is sent.