### PR TITLE
Fix everyman base date/number.

### DIFF
--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -15,8 +15,8 @@ case object Speedy extends CrosswordType {
 }
 case object Everyman extends CrosswordType {
   val name = "everyman"
-  def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(3657, new LocalDate(2016, 11, 6), 7)(date)
-  def getDate(no: Int) = CrosswordTypeHelpers.getDateForWeeklyXWord(3657, new LocalDate(2016, 11, 6), 7)(no)
+  def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(3706, new LocalDate(2017, 10, 22), 7)(date)
+  def getDate(no: Int) = CrosswordTypeHelpers.getDateForWeeklyXWord(3706, new LocalDate(2017, 10, 22), 7)(no)
 }
 case object Quiptic extends CrosswordType {
   val name = "quiptic"


### PR DESCRIPTION
Somehow the status checker is out of sync for everyman crosswords - it keeps alerting for a crossword that isn't due for over a week. This should fix that change.