### PR TITLE
Use search to determine prize and cryptic numbers/dates

### DIFF
--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -1,6 +1,6 @@
 package com.gu.crossword.crosswords.models
 
-import org.joda.time.{Days, LocalDate, Weeks}
+import org.joda.time.{ Days, LocalDate, Weeks }
 
 import scala.annotation.tailrec
 
@@ -67,7 +67,7 @@ case object Quick extends CrosswordType {
 
   def getDate(no: Int) = {
     val dayDiff = no - baseNo
-//    Divide by 6 as crossword number is only incremented 6 days a week
+    //    Divide by 6 as crossword number is only incremented 6 days a week
     val numberOfSundays = Math.floor(dayDiff / 6.0).toInt
     val date = basePubDate.plusDays(dayDiff + numberOfSundays)
     if (date.getDayOfWeek == 7) None
@@ -87,14 +87,16 @@ case object Cryptic extends SearchBasedCrosswordType {
 trait SearchBasedCrosswordType extends CrosswordType {
   def validate(date: LocalDate): Boolean
 
-  final def getNo(target: LocalDate): Option[Int] = {
-    search(Right(target), baseNo, basePubDate).collect {
-      case (number, date) if validate(date) => number
+  final def getNo(date: LocalDate): Option[Int] = {
+    if (validate(date)) {
+      search(Right(date), baseNo, basePubDate).map { case (no, _) => no }
+    } else {
+      None
     }
   }
 
-  final def getDate(target: Int): Option[LocalDate] = {
-    search(Left(target), baseNo, basePubDate).collect {
+  final def getDate(no: Int): Option[LocalDate] = {
+    search(Left(no), baseNo, basePubDate).collect {
       case (_, date) if validate(date) => date
     }
   }
@@ -114,7 +116,7 @@ trait SearchBasedCrosswordType extends CrosswordType {
       case _ =>
         val hitTarget = target == Left(number) || target == Right(date)
 
-        if (hitTarget  && !isSunday && !isChristmas) {
+        if (hitTarget && !isSunday && !isChristmas) {
           Some((number, date))
         } else if (isSunday || isChristmas) {
           search(target, number, date.plusDays(1))

--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -1,9 +1,15 @@
 package com.gu.crossword.crosswords.models
 
-import org.joda.time.{ Days, LocalDate, Weeks }
+import org.joda.time.{Days, LocalDate, Weeks}
+
+import scala.annotation.tailrec
 
 sealed trait CrosswordType extends Product with Serializable {
   def name: String
+
+  def baseNo: Int
+  def basePubDate: LocalDate
+
   def getNo(date: LocalDate): Option[Int]
   def getDate(no: Int): Option[LocalDate]
 }
@@ -36,26 +42,13 @@ case object Weekend extends CrosswordType {
   def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(baseNo, basePubDate, 6)(date)
   def getDate(no: Int) = CrosswordTypeHelpers.getDateForWeeklyXWord(baseNo, basePubDate, 6)(no)
 }
-case object Prize extends CrosswordType {
+case object Prize extends SearchBasedCrosswordType {
   val name = "prize"
   val basePubDate = new LocalDate(2017, 10, 28)
   val baseNo = 27340
 
-  def getNo(date: LocalDate) = {
-    if (6 != date.getDayOfWeek) None
-    else {
-      val weekDiff = Weeks.weeksBetween(basePubDate, date).getWeeks
-      Some(baseNo + weekDiff * 6)
-    }
-  }
-
-  def getDate(no: Int) = {
-    val dayDiff = no - baseNo
-//    Divide by 6 as crossword number is only incremented 6 days a week
-    val numberOfSundays = Math.floor(dayDiff / 6.0).toInt
-    val date = basePubDate.plusDays(dayDiff + numberOfSundays)
-    if (6 != date.getDayOfWeek) None
-    else Some(date)
+  final override def validate(date: LocalDate): Boolean = {
+    date.getDayOfWeek == 6
   }
 }
 case object Quick extends CrosswordType {
@@ -81,27 +74,54 @@ case object Quick extends CrosswordType {
     else Some(date)
   }
 }
-case object Cryptic extends CrosswordType {
+case object Cryptic extends SearchBasedCrosswordType {
   val name = "cryptic"
   val baseNo = 27347
   val basePubDate = new LocalDate(2017, 11, 6)
 
-  def getNo(date: LocalDate) = {
-    if (date.getDayOfWeek == 6 || date.getDayOfWeek == 7) None
-    else {
-      val dayDiff = Days.daysBetween(basePubDate, date).getDays
-      val numberOfSundays = Math.floor(dayDiff / 7.0).toInt
-      Some(baseNo + dayDiff - numberOfSundays)
+  override def validate(date: LocalDate): Boolean = {
+    date.getDayOfWeek != 6
+  }
+}
+
+trait SearchBasedCrosswordType extends CrosswordType {
+  def validate(date: LocalDate): Boolean
+
+  final def getNo(target: LocalDate): Option[Int] = {
+    search(Right(target), baseNo, basePubDate).collect {
+      case (number, date) if validate(date) => number
     }
   }
-  def getDate(no: Int) = {
-    val dayDiff = no - baseNo
-//    Divide by 6 as crossword number is only incremented 6 days a week
-    val numberOfSundays = Math.floor(dayDiff / 6.0).toInt
-    val date = basePubDate.plusDays(dayDiff + numberOfSundays)
 
-    if (date.getDayOfWeek == 6 || date.getDayOfWeek == 7) None
-    else Some(date)
+  final def getDate(target: Int): Option[LocalDate] = {
+    search(Left(target), baseNo, basePubDate).collect {
+      case (_, date) if validate(date) => date
+    }
+  }
+
+  @tailrec
+  private def search(target: Either[Int, LocalDate], number: Int, date: LocalDate): Option[(Int, LocalDate)] = {
+    val isSunday = date.getDayOfWeek == 7
+    val isChristmas = date.getDayOfMonth == 25 && date.getMonthOfYear == 12
+
+    target match {
+      case Left(t) if number > t =>
+        None
+
+      case Right(t) if date.compareTo(t) > 0 =>
+        None
+
+      case _ =>
+        val hitTarget = target == Left(number) || target == Right(date)
+
+        if (hitTarget  && !isSunday && !isChristmas) {
+          Some((number, date))
+        } else if (isSunday || isChristmas) {
+          search(target, number, date.plusDays(1))
+        } else {
+          search(target, number + 1, date.plusDays(1))
+        }
+    }
   }
 }
 

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -2,7 +2,7 @@ package com.gu.crossword.crosswords
 
 import com.gu.crossword.crosswords.models._
 import org.joda.time.LocalDate
-import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.{ FunSuite, MustMatchers }
 
 class CrosswordTypeTest extends FunSuite with MustMatchers {
   test("test getNoForWeeklyXword") {

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -2,10 +2,9 @@ package com.gu.crossword.crosswords
 
 import com.gu.crossword.crosswords.models._
 import org.joda.time.LocalDate
-import org.scalatest.FunSuite
+import org.scalatest.{FunSuite, MustMatchers}
 
-class CrosswordTypeTest extends FunSuite {
-
+class CrosswordTypeTest extends FunSuite with MustMatchers {
   test("test getNoForWeeklyXword") {
     assert(Speedy.getNo(new LocalDate(2017, 7, 23)) === Some(1138))
     assert(Speedy.getNo(new LocalDate(2016, 11, 4)) === None)
@@ -14,8 +13,8 @@ class CrosswordTypeTest extends FunSuite {
   }
 
   test("test getNoForPrizeXword") {
-    assert(Prize.getNo(new LocalDate(2016, 11, 19)) === Some(27046))
-    assert(Prize.getNo(new LocalDate(2016, 11, 18)) === None)
+    assert(Prize.getNo(new LocalDate(2017, 12, 23)) === Some(27388))
+    assert(Prize.getNo(new LocalDate(2017, 12, 22)) === None)
   }
 
   test("test getNoForQuickXword") {
@@ -24,17 +23,17 @@ class CrosswordTypeTest extends FunSuite {
   }
 
   test("test getNoForCrypticXword") {
-    assert(Cryptic.getNo(new LocalDate(2017, 10, 10)) === Some(27324))
-    assert(Cryptic.getNo(new LocalDate(2016, 12, 4)) === None)
+    assert(Cryptic.getNo(new LocalDate(2017, 11, 6)) === Some(27347))
+    assert(Cryptic.getNo(new LocalDate(2017, 11, 11)) === None)
   }
 
   test("test getDateForQuickXword") {
     assert(Quick.getDate(14803) === Some(new LocalDate(2017, 10, 17)))
   }
 
-  test("test getDateForCripticXword") {
-    assert(Cryptic.getDate(27326) === Some(new LocalDate(2017, 10, 12)))
-    assert(Cryptic.getDate(27346) === None)
+  test("test getDateForCrypticXword") {
+    assert(Cryptic.getDate(27347) === Some(new LocalDate(2017, 11, 6)))
+    assert(Cryptic.getDate(27352) === None)
   }
 
   test("test getDateForWeeklyXword") {
@@ -45,7 +44,60 @@ class CrosswordTypeTest extends FunSuite {
   }
 
   test("test getDateForPrizeXword") {
-    assert(Prize.getDate(27304) === Some(new LocalDate(2017, 9, 16)))
+    assert(Prize.getDate(27388) === Some(new LocalDate(2017, 12, 23)))
   }
 
+  test("test christmas") {
+    Cryptic.getNo(new LocalDate(2017, 12, 25)) mustBe empty
+    Prize.getNo(new LocalDate(2017, 12, 25)) mustBe empty
+    Quiptic.getNo(new LocalDate(2017, 12, 25)) must contain(945)
+  }
+
+  test("prize and cryptic after christmas") {
+    val saturday = new LocalDate(2017, 12, 30)
+    val monday = new LocalDate(2018, 1, 1)
+
+    Prize.getDate(27393) must contain(saturday)
+    Prize.getNo(saturday) must contain(27393)
+    Cryptic.getDate(27393) mustBe empty
+    Cryptic.getNo(saturday) mustBe empty
+
+    Prize.getDate(27394) mustBe empty
+    Prize.getNo(monday) mustBe empty
+    Cryptic.getDate(27394) must contain(monday)
+    Cryptic.getNo(monday) must contain(27394)
+  }
+
+  test("test christmas 2017") {
+    // 'twas the night before the night before christmas...
+    // and the Guardian elves saw it was a Saturday and published a Prize crossword instead of a Cryptic one
+    Prize.getDate(27388) must contain(new LocalDate(2017, 12, 23))
+
+    // 'twas actually the night before christmas and it was a Sunday...
+    // so nothing was stirring, not even a mouse and certainly not any crosswords
+    Cryptic.getNo(new LocalDate(2017, 12, 24)) mustBe empty
+    Prize.getNo(new LocalDate(2017, 12, 24)) mustBe empty
+
+    // Noddy says it's Christmas and The Guardian is not publishing a paper
+    // so no cryptic or prize
+    Cryptic.getNo(new LocalDate(2017, 12, 25)) mustBe empty
+    Prize.getNo(new LocalDate(2017, 12, 25)) mustBe empty
+
+    // then we all forgot about how crossword status checker works until next year!
+    Cryptic.getDate(27389) must contain(new LocalDate(2017, 12, 26)) // Tuesday
+    Cryptic.getDate(27390) must contain(new LocalDate(2017, 12, 27)) // Wednesday
+    Cryptic.getDate(27391) must contain(new LocalDate(2017, 12, 28)) // Thursday
+    Cryptic.getDate(27392) must contain(new LocalDate(2017, 12, 29)) // Friday
+
+    // Saturday (Prize)
+    Prize.getDate(27393) must contain(new LocalDate(2017, 12, 30))
+    Cryptic.getDate(27393) mustBe empty
+  }
+
+  test("test base case") {
+    CrosswordTypeHelpers.allTypes.foreach { crossword =>
+      crossword.getDate(crossword.baseNo) must contain(crossword.basePubDate)
+      crossword.getNo(crossword.basePubDate) must contain(crossword.baseNo)
+    }
+  }
 }


### PR DESCRIPTION
The checker has desynchronised from reality again, this time for prize and cryptic crosswords. This PR re-works that code to be a search from the base number and date to the one requested.

I've added safety catches if the current search number/date overshoots the target so hopefully we're safe from infinite loops even though it's `@tailrec`.

The big downside of this new approach is that is does not currently work for dates or numbers prior to the base.

I've also added some tests describing the behaviour around this Christmas.

We could consider using this strategy for `Quick` as well since that still has the debatable call to `Math.floor`