### PR TITLE
Use search for Quick crosswords

### DIFF
--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -57,7 +57,7 @@ case object Quick extends EveryDayExceptSundayCrossword {
   val basePubDate = new LocalDate(2017, 11, 6)
 
   override def validate(date: LocalDate): Boolean = {
-    true // every day except sunday
+    date.getDayOfWeek != 7 // not sundays
   }
 }
 case object Cryptic extends EveryDayExceptSundayCrossword {
@@ -66,7 +66,7 @@ case object Cryptic extends EveryDayExceptSundayCrossword {
   val basePubDate = new LocalDate(2017, 11, 6)
 
   override def validate(date: LocalDate): Boolean = {
-    date.getDayOfWeek != 6 // every weekday
+    date.getDayOfWeek < 6 // every weekday
   }
 }
 

--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -42,49 +42,35 @@ case object Weekend extends CrosswordType {
   def getNo(date: LocalDate) = CrosswordTypeHelpers.getNoForWeeklyXword(baseNo, basePubDate, 6)(date)
   def getDate(no: Int) = CrosswordTypeHelpers.getDateForWeeklyXWord(baseNo, basePubDate, 6)(no)
 }
-case object Prize extends SearchBasedCrosswordType {
+case object Prize extends EveryDayExceptSundayCrossword {
   val name = "prize"
   val basePubDate = new LocalDate(2017, 10, 28)
   val baseNo = 27340
 
   final override def validate(date: LocalDate): Boolean = {
-    date.getDayOfWeek == 6
+    date.getDayOfWeek == 6 // only saturdays
   }
 }
-case object Quick extends CrosswordType {
+case object Quick extends EveryDayExceptSundayCrossword {
   val name = "quick"
   val baseNo = 14820
   val basePubDate = new LocalDate(2017, 11, 6)
 
-  def getNo(date: LocalDate) = {
-    if (date.getDayOfWeek == 7) None
-    else {
-      val dayDiff = Days.daysBetween(basePubDate, date).getDays
-      val numberOfSundays = Math.floor(dayDiff / 7.0).toInt
-      Some(baseNo + dayDiff - numberOfSundays)
-    }
-  }
-
-  def getDate(no: Int) = {
-    val dayDiff = no - baseNo
-    //    Divide by 6 as crossword number is only incremented 6 days a week
-    val numberOfSundays = Math.floor(dayDiff / 6.0).toInt
-    val date = basePubDate.plusDays(dayDiff + numberOfSundays)
-    if (date.getDayOfWeek == 7) None
-    else Some(date)
+  override def validate(date: LocalDate): Boolean = {
+    true // every day except sunday
   }
 }
-case object Cryptic extends SearchBasedCrosswordType {
+case object Cryptic extends EveryDayExceptSundayCrossword {
   val name = "cryptic"
   val baseNo = 27347
   val basePubDate = new LocalDate(2017, 11, 6)
 
   override def validate(date: LocalDate): Boolean = {
-    date.getDayOfWeek != 6
+    date.getDayOfWeek != 6 // every weekday
   }
 }
 
-trait SearchBasedCrosswordType extends CrosswordType {
+trait EveryDayExceptSundayCrossword extends CrosswordType {
   def validate(date: LocalDate): Boolean
 
   final def getNo(date: LocalDate): Option[Int] = {

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -18,8 +18,8 @@ class CrosswordTypeTest extends FunSuite with MustMatchers {
   }
 
   test("test getNoForQuickXword") {
-    assert(Quick.getNo(new LocalDate(2016, 11, 5)) === Some(14507))
-    assert(Quick.getNo(new LocalDate(2016, 11, 6)) === None)
+    assert(Quick.getNo(new LocalDate(2017, 11, 8)) === Some(14822))
+    assert(Quick.getNo(new LocalDate(2017, 11, 12)) === None)
   }
 
   test("test getNoForCrypticXword") {
@@ -28,7 +28,7 @@ class CrosswordTypeTest extends FunSuite with MustMatchers {
   }
 
   test("test getDateForQuickXword") {
-    assert(Quick.getDate(14803) === Some(new LocalDate(2017, 10, 17)))
+    assert(Quick.getDate(14826) === Some(new LocalDate(2017, 11, 13)))
   }
 
   test("test getDateForCrypticXword") {
@@ -92,6 +92,11 @@ class CrosswordTypeTest extends FunSuite with MustMatchers {
     // Saturday (Prize)
     Prize.getDate(27393) must contain(new LocalDate(2017, 12, 30))
     Cryptic.getDate(27393) mustBe empty
+  }
+
+  test("Quick 2018-01-06") {
+    Quick.getDate(14872) must contain(new LocalDate(2018, 1, 6))
+    Quick.getNo(new LocalDate(2018, 1, 6)) must contain(14872)
   }
 
   test("test base case") {


### PR DESCRIPTION
Quick crosswords have gone "out by one", just like Cryptic and Prize before them. This PR makes the checker use the same search strategy as the others to fix the problem.