### PR TITLE
lists S3 objects by prefix to avoid checking a truncated set of files

### DIFF
--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -3,7 +3,7 @@ package com.gu.crossword.crosswords
 import com.gu.crossword.Config
 import com.gu.crossword.services.S3.getS3Client
 
-import org.joda.time.{ LocalDate }
+import org.joda.time.{LocalDate}
 import scala.collection.JavaConversions._
 
 trait CrosswordStore {
@@ -16,7 +16,10 @@ trait CrosswordStore {
 
   private def getMatchingCrosswordFileKeys(id: Option[String], crosswordType: String, bucketName: String, format: String)(config: Config): List[String] = {
     if (id.isDefined) {
-      val files = config.s3Client.listObjects(bucketName, s"${id.get}.$format").getObjectSummaries.toList.map(_.getKey)
+      val files = config.s3Client.listObjects(bucketName, s"${id.get}.$format")
+        .getObjectSummaries
+        .toList
+        .map(_.getKey)
       val exactMatch = files.filter(_ == s"${id.get}.$format")
       exactMatch.length match {
         case 1 => exactMatch

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -15,8 +15,8 @@ trait CrosswordStore {
   }
 
   private def getMatchingCrosswordFileKeys(id: Option[String], crosswordType: String, bucketName: String, format: String)(config: Config): List[String] = {
-    val files = config.s3Client.listObjects(bucketName).getObjectSummaries.toList.map(_.getKey).filter(_.contains(s".$format"))
     if (id.isDefined) {
+      val files = config.s3Client.listObjects(bucketName, s"${id.get}.$format").getObjectSummaries.toList.map(_.getKey)
       val exactMatch = files.filter(_ == s"${id.get}.$format")
       exactMatch.length match {
         case 1 => exactMatch
@@ -26,7 +26,6 @@ trait CrosswordStore {
           else filterByType(withMatchingId, crosswordType).fold(withMatchingId)(List(_))
       }
     } else List.empty
-
   }
 
   private def getInBucketStatus(numMatchingKeys: Int) = {

--- a/update-lambda.sh
+++ b/update-lambda.sh
@@ -19,4 +19,5 @@ jar_file=$(echo $my_dir/target/scala-2.11/crossword-status-checker-assembly*.jar
 aws lambda update-function-code \
   --function-name crosswords-status-checker-scheduling-$STAGE \
   --zip-file fileb://$jar_file \
-  --profile $PROFILE
+  --profile $PROFILE \
+  --region eu-west-1


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
The current crossword checker, S3 check, is not returning files found despite them existing in the bucket. This is possibly due to the possibility that object listings returned by the S3 can be truncated, and there are a large number of files in the crossword buckets. 

This PR attempts to resolve this issue by reducing the number of objects returned by adding a prefix parameter to the call.

Before:
![image](https://user-images.githubusercontent.com/4633246/96428486-b79c4c00-11f7-11eb-9342-4bb6b47a0d01.png)

After:
![image](https://user-images.githubusercontent.com/4633246/96428516-bf5bf080-11f7-11eb-93bb-a4cd89a50f10.png)


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy to PROD and check???

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

The crossword checker returns accurate results related to the presence of files in S3.

