### PR TITLE
Upgrading the version of sbt to 0.13.18

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.18

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -3,7 +3,7 @@ package com.gu.crossword.crosswords
 import com.gu.crossword.Config
 import com.gu.crossword.services.S3.getS3Client
 
-import org.joda.time.{LocalDate}
+import org.joda.time.{ LocalDate }
 import scala.collection.JavaConversions._
 
 trait CrosswordStore {


### PR DESCRIPTION
This build was failing to build on my machine with a:

```
[info] Compiling 1 Scala source to /Users/francis_rhys-jones/code/crossword-status-checker/project/target/scala-2.10/sbt-0.13/classes...
sbt.InvalidComponent: Could not find required component 'xsbti'
```

There are various confusing bug report and workarounds:

https://github.com/sbt/sbt/issues/6447

Upgrading the version of sbt seemed to work for me. 

Upgrading any further would require some more indepth upgrading of the plugin dependencies so Ive left it at the latest 0.13.x release.

Ive also checked in some scalariform formatting that was missed.
