### PR TITLE
Account for skipped publish dates on christmas in weekly crosswords

### DIFF
--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -148,11 +148,13 @@ object CrosswordTypeHelpers {
     skippedPublishes: List[LocalDate],
     direction: Int
   ): LocalDate = {
+    // if this date was skipped, move onto next week without touching weekDiff
     if (skippedPublishes.contains(date)) {
       accountForSkippedWeeks(date.plusWeeks(direction), weekDiff, skippedPublishes, direction)
+    // base case; when the difference between the week you're on and the week you want to get to is 0, you're there
     } else if (weekDiff == 0) {
       date
-    // if this date was skipped, move onto next week without touching weekDiff
+    // move 1 week in the given direction, and subtract 1 from the difference between week numbers
     } else {
       accountForSkippedWeeks(date.plusWeeks(direction), weekDiff - direction, skippedPublishes, direction)
     }

--- a/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/models/CrosswordType.scala
@@ -136,31 +136,29 @@ object CrosswordTypeHelpers {
 
   // repeatedly add (or subtract!) 1 week to `date`, until the weekDiff hits 0,
   // skipping the dates that are marked as nothing published.
-  @tailrec def accountForSkippedWeeks(
+  def accountForSkippedWeeks(date: LocalDate, weekDiff: Int, skippedPublishes: List[LocalDate]): LocalDate =
+    accountForSkippedWeeks(date, weekDiff, skippedPublishes, direction = if (weekDiff > 0) 1 else -1)
+
+  // passes "direction" through as a parameter so we can continue skipping weeks in the correct direction
+  // even at the end of our looping
+  @tailrec
+  private def accountForSkippedWeeks(
     date: LocalDate,
     weekDiff: Int,
-    skippedPublishes: List[LocalDate]
+    skippedPublishes: List[LocalDate],
+    direction: Int
   ): LocalDate = {
-    val direction = if (weekDiff > 0) 1 else -1
-
-    // shouldn't be called by recursion - main base case is weekDiff == 1 or -1
-    if (weekDiff == 0) {
+    if (skippedPublishes.contains(date)) {
+      accountForSkippedWeeks(date.plusWeeks(direction), weekDiff, skippedPublishes, direction)
+    } else if (weekDiff == 0) {
       date
-    // base case; check that the next week in this direction isn't skipped; if it is move one more week and try again
-    } else if (weekDiff == 1 || weekDiff == -1) {
-      val candidate = date.plusWeeks(direction)
-      if (skippedPublishes.contains(candidate)) {
-        accountForSkippedWeeks(candidate, weekDiff, skippedPublishes)
-      } else {
-        candidate
-      }
     // if this date was skipped, move onto next week without touching weekDiff
-    } else if (skippedPublishes.contains(date)) {
-      accountForSkippedWeeks(date.plusWeeks(direction), weekDiff, skippedPublishes)
     } else {
-      accountForSkippedWeeks(date.plusWeeks(direction), weekDiff - direction, skippedPublishes)
+      accountForSkippedWeeks(date.plusWeeks(direction), weekDiff - direction, skippedPublishes, direction)
     }
   }
+
+
   def getDateForWeeklyXWord(
     baseNo: Int,
     basePubDate: LocalDate,

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -11,6 +11,13 @@ class CrosswordTypeTest extends AnyFunSuite with Matchers {
     assert(Speedy.getNo(new LocalDate(2016, 11, 4)) === None)
     assert(Quiptic.getNo(new LocalDate(2016, 11, 7)) === Some(886))
     assert(Everyman.getNo(new LocalDate(2017, 10, 15)) === Some(3705))
+
+    assert(Weekend.getNo(new LocalDate(2017, 11, 4)) === Some(357))
+    // Weekend skipped a week at 573 (the original date would have fallen on xmas day)
+    assert(Weekend.getNo(new LocalDate(2021, 12, 18)) === Some(572))
+    assert(Weekend.getNo(new LocalDate(2021, 12, 25)) === None)
+    assert(Weekend.getNo(new LocalDate(2022, 1, 1)) === Some(573))
+    assert(Weekend.getNo(new LocalDate(2023, 6, 24)) === Some(650))
   }
 
   test("test getNoForPrizeXword") {
@@ -42,6 +49,12 @@ class CrosswordTypeTest extends AnyFunSuite with Matchers {
     assert(Speedy.getDate(1153) === Some(new LocalDate(2017, 11, 5)))
     assert(Everyman.getDate(3696) === Some(new LocalDate(2017, 8, 13)))
     assert(Quiptic.getDate(923) === Some(new LocalDate(2017, 7, 24)))
+
+    assert(Weekend.getDate(357) === Some(new LocalDate(2017, 11, 4)))
+    // Weekend skipped a week at 573 (the original date would have fallen on xmas day)
+    assert(Weekend.getDate(572) === Some(new LocalDate(2021, 12, 18)))
+    assert(Weekend.getDate(573) === Some(new LocalDate(2022, 1, 1)))
+    assert(Weekend.getDate(650) === Some(new LocalDate(2023, 6, 24)))
   }
 
   test("test getDateForPrizeXword") {

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -9,50 +9,18 @@ class CrosswordTypeTest extends AnyFunSuite with Matchers {
   test("test getNoForWeeklyXword") {
     assert(Speedy.getNo(new LocalDate(2017, 7, 23)) === Some(1138))
     assert(Speedy.getNo(new LocalDate(2016, 11, 4)) === None)
+    assert(Speedy.getNo(new LocalDate(2023, 6, 18)) === Some(1445))
     assert(Quiptic.getNo(new LocalDate(2016, 11, 7)) === Some(886))
+    assert(Quiptic.getNo(new LocalDate(2017, 12, 25)) === Some(945)) // quiptic publishes/published on xmas
+    assert(Quiptic.getNo(new LocalDate(2023, 6, 19)) === Some(1231))
     assert(Everyman.getNo(new LocalDate(2017, 10, 15)) === Some(3705))
+    assert(Everyman.getNo(new LocalDate(2023, 6, 18)) === Some(4000))
 
     assert(Weekend.getNo(new LocalDate(2017, 11, 4)) === Some(357))
-    // Weekend skipped a week at 573 (the original date would have fallen on xmas day)
     assert(Weekend.getNo(new LocalDate(2021, 12, 18)) === Some(572))
     assert(Weekend.getNo(new LocalDate(2021, 12, 25)) === None)
     assert(Weekend.getNo(new LocalDate(2022, 1, 1)) === Some(573))
     assert(Weekend.getNo(new LocalDate(2023, 6, 24)) === Some(650))
-  }
-
-  test("test get*ForWeeklyXword for hypothetical crossword type with multiple skipped publishes") {
-    val baseNo = 200
-    val basePubDate = new LocalDate(2010, 1, 1)
-    val publicationDayOfWeek = 5 // Friday
-    val skips = List(new LocalDate(2010, 1, 15), new LocalDate(2010, 1, 22))
-
-
-    /*     January 2010
-     * Su Mo Tu We Th Fr Sa
-     *                 1  2
-     *  3  4  5  6  7  8  9
-     * 10 11 12 13 14 15 16
-     * 17 18 19 20 21 22 23
-     * 24 25 26 27 28 29 30
-     * 31
-     *    February 2010
-     * Su Mo Tu We Th Fr Sa
-     *     1  2  3  4  5  6
-     *  7  8  9 10 11 12 13
-     */
-    val getDateFn = CrosswordTypeHelpers.getDateForWeeklyXWord(baseNo, basePubDate, publicationDayOfWeek, skips) _
-    assert(getDateFn(200) === Some(new LocalDate(2010, 1, 1)))
-    assert(getDateFn(201) === Some(new LocalDate(2010, 1, 8)))
-    assert(getDateFn(202) === Some(new LocalDate(2010, 1, 29))) // skipped 15 and 22
-    assert(getDateFn(203) === Some(new LocalDate(2010, 2, 5)))
-
-    val getNoFn = CrosswordTypeHelpers.getNoForWeeklyXword(baseNo, basePubDate, publicationDayOfWeek, skips) _
-    assert(getNoFn(new LocalDate(2010, 1, 1)) === Some(200))
-    assert(getNoFn(new LocalDate(2010, 1, 8)) === Some(201))
-    assert(getNoFn(new LocalDate(2010, 1, 29)) === Some(202))
-    assert(getNoFn(new LocalDate(2010, 2, 5)) === Some(203))
-    assert(getNoFn(new LocalDate(2010, 1, 15)) === None)
-    assert(getNoFn(new LocalDate(2010, 1, 22)) === None)
   }
 
   test("test getNoForPrizeXword") {
@@ -82,11 +50,14 @@ class CrosswordTypeTest extends AnyFunSuite with Matchers {
   test("test getDateForWeeklyXword") {
     assert(Speedy.getDate(1151) === Some(new LocalDate(2017, 10, 22)))
     assert(Speedy.getDate(1153) === Some(new LocalDate(2017, 11, 5)))
+    assert(Speedy.getDate(1445) === Some(new LocalDate(2023, 6, 18)))
     assert(Everyman.getDate(3696) === Some(new LocalDate(2017, 8, 13)))
+    assert(Everyman.getDate(4000) === Some(new LocalDate(2023, 6, 18)))
     assert(Quiptic.getDate(923) === Some(new LocalDate(2017, 7, 24)))
+    assert(Quiptic.getDate(945) === Some(new LocalDate(2017, 12, 25)))
+    assert(Quiptic.getDate(1231) === Some(new LocalDate(2023, 6, 19)))
 
     assert(Weekend.getDate(357) === Some(new LocalDate(2017, 11, 4)))
-    // Weekend skipped a week at 573 (the original date would have fallen on xmas day)
     assert(Weekend.getDate(572) === Some(new LocalDate(2021, 12, 18)))
     assert(Weekend.getDate(573) === Some(new LocalDate(2022, 1, 1)))
     assert(Weekend.getDate(650) === Some(new LocalDate(2023, 6, 24)))

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordTypeTest.scala
@@ -20,6 +20,41 @@ class CrosswordTypeTest extends AnyFunSuite with Matchers {
     assert(Weekend.getNo(new LocalDate(2023, 6, 24)) === Some(650))
   }
 
+  test("test get*ForWeeklyXword for hypothetical crossword type with multiple skipped publishes") {
+    val baseNo = 200
+    val basePubDate = new LocalDate(2010, 1, 1)
+    val publicationDayOfWeek = 5 // Friday
+    val skips = List(new LocalDate(2010, 1, 15), new LocalDate(2010, 1, 22))
+
+
+    /*     January 2010
+     * Su Mo Tu We Th Fr Sa
+     *                 1  2
+     *  3  4  5  6  7  8  9
+     * 10 11 12 13 14 15 16
+     * 17 18 19 20 21 22 23
+     * 24 25 26 27 28 29 30
+     * 31
+     *    February 2010
+     * Su Mo Tu We Th Fr Sa
+     *     1  2  3  4  5  6
+     *  7  8  9 10 11 12 13
+     */
+    val getDateFn = CrosswordTypeHelpers.getDateForWeeklyXWord(baseNo, basePubDate, publicationDayOfWeek, skips) _
+    assert(getDateFn(200) === Some(new LocalDate(2010, 1, 1)))
+    assert(getDateFn(201) === Some(new LocalDate(2010, 1, 8)))
+    assert(getDateFn(202) === Some(new LocalDate(2010, 1, 29))) // skipped 15 and 22
+    assert(getDateFn(203) === Some(new LocalDate(2010, 2, 5)))
+
+    val getNoFn = CrosswordTypeHelpers.getNoForWeeklyXword(baseNo, basePubDate, publicationDayOfWeek, skips) _
+    assert(getNoFn(new LocalDate(2010, 1, 1)) === Some(200))
+    assert(getNoFn(new LocalDate(2010, 1, 8)) === Some(201))
+    assert(getNoFn(new LocalDate(2010, 1, 29)) === Some(202))
+    assert(getNoFn(new LocalDate(2010, 2, 5)) === Some(203))
+    assert(getNoFn(new LocalDate(2010, 1, 15)) === None)
+    assert(getNoFn(new LocalDate(2010, 1, 22)) === None)
+  }
+
   test("test getNoForPrizeXword") {
     assert(Prize.getNo(new LocalDate(2017, 12, 23)) === Some(27388))
     assert(Prize.getNo(new LocalDate(2017, 12, 22)) === None)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Weekend crossword skipped a week for xmas 2021, but the status checker only knows about skipping christmas for dailies! It's been checking the wrong crossword ID each week (and on closer observation, was doing the same for the other weeklies. Except quiptic, which [did publish on christmas](https://www.theguardian.com/crosswords/quiptic/945).)

Update the weekly getNumber/getDate functions to account for christmas when calculating (but also allow crossword types like Quiptic to opt-out and publish on christmas 😵 )

## How to test

Check the unit tests. Any cases missed?

## How can we measure success?

No more confusion about "unready" crosswords

