### PR TITLE
Add API checker tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,15 @@ import sbt._
 import Keys._
 
 val basicSettings = Seq(
-  organization  := "com.gu",
-  description   := "AWS Lambda to check crossword status.",
-  scalaVersion  := "2.13.10",
+  organization := "com.gu",
+  description := "AWS Lambda to check crossword status.",
+  scalaVersion := "2.13.10",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"),
   assemblyJarName := "crossword-status-checker.jar",
   assembly / test := (Test / test).value,
   assembly / assemblyMergeStrategy := {
-    case PathList(ps @ _*) if ps.last == "module-info.class" => MergeStrategy.discard
+    case PathList(ps @ _*) if ps.last == "module-info.class" =>
+      MergeStrategy.discard
     case path => MergeStrategy.defaultMergeStrategy(path)
   }
 )
@@ -18,17 +19,16 @@ val awsVersion = "1.12.359"
 
 val root = Project("crossword-status-checker", file("."))
   .settings(
-
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
       "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
       "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+      "com.squareup.okhttp3" % "mockwebserver" % "4.10.0" % "test",
       "com.gu" %% "content-api-client-aws" % "0.7",
       "org.scalatest" %% "scalatest" % "3.2.14" % "test",
       "org.json4s" %% "json4s-native" % "4.0.6"
     )
   )
   .settings(basicSettings)
-

--- a/src/main/scala/com/gu/crossword/Config.scala
+++ b/src/main/scala/com/gu/crossword/Config.scala
@@ -3,15 +3,12 @@ package com.gu.crossword
 import java.util.Properties
 
 import com.amazonaws.auth.{
-  AWSCredentialsProvider,
   AWSCredentialsProviderChain,
-  DefaultAWSCredentialsProviderChain,
-  STSAssumeRoleSessionCredentialsProvider
+  DefaultAWSCredentialsProviderChain
 }
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.regions.{Region, Regions}
+
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.contentapi.client.IAMSigner
 import com.gu.crossword.crosswords.RequestBuilderWithSigner
 import com.gu.crossword.services.S3.getS3Client
 import com.gu.crossword.services.SNS.getSNSClient
@@ -50,24 +47,9 @@ class Config(val context: Context) {
   val capiKey = getConfig("capi.key")
 
   val capiPreviewUrl = getConfig("capi.preview.iam-url")
+  val capiPreviewRole = getConfig("capi.preview.role")
 
-  val signer = {
-    val capiPreviewRole = getConfig("capi.preview.role")
-
-    val capiPreviewCredentials: AWSCredentialsProvider = {
-      new AWSCredentialsProviderChain(
-        new ProfileCredentialsProvider("capi"),
-        new STSAssumeRoleSessionCredentialsProvider.Builder(
-          capiPreviewRole,
-          "capi"
-        ).build()
-      )
-    }
-
-    new IAMSigner(capiPreviewCredentials, awsRegion)
-  }
-
-  val requestBuilder = new RequestBuilderWithSigner(signer)
+  val requestBuilder = new RequestBuilderWithSigner(capiPreviewRole, awsRegion)
 
   val flexUrl = getConfig("flex.api.loadbalancer")
   val flexFindByPathEndpoint = getConfig("flex.api.findbypathendpoint")

--- a/src/main/scala/com/gu/crossword/Config.scala
+++ b/src/main/scala/com/gu/crossword/Config.scala
@@ -12,6 +12,7 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.contentapi.client.IAMSigner
+import com.gu.crossword.crosswords.RequestBuilderWithSigner
 import com.gu.crossword.services.S3.getS3Client
 import com.gu.crossword.services.SNS.getSNSClient
 
@@ -65,6 +66,8 @@ class Config(val context: Context) {
 
     new IAMSigner(capiPreviewCredentials, awsRegion)
   }
+
+  val requestBuilder = new RequestBuilderWithSigner(signer)
 
   val flexUrl = getConfig("flex.api.loadbalancer")
   val flexFindByPathEndpoint = getConfig("flex.api.findbypathendpoint")

--- a/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/src/main/scala/com/gu/crossword/Lambda.scala
@@ -62,7 +62,10 @@ class Lambda
         "Can check a maximum of 10 days"
       } else {
         val statuses = Await
-          .result(checkNextNDays(noDaysToCheck)(config), 10.seconds)
+          .result(
+            checkNextNDays(noDaysToCheck)(config, requestBuilder),
+            10.seconds
+          )
           .flatten
 
         // alert if any of the crosswords are not ready
@@ -71,11 +74,6 @@ class Lambda
         s"checked $noDaysToCheck days"
       }
     } else if (event.containsKey("dateToCheck")) {
-      val requestBuilder =
-        new RequestBuilderWithSigner(
-          config.capiPreviewRole,
-          Constants.awsRegion.toString
-        )
 
       val dateToCheck = event.get("dateToCheck").toString
       val d = LocalDate.parse(dateToCheck)

--- a/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/src/main/scala/com/gu/crossword/Lambda.scala
@@ -1,8 +1,8 @@
 package com.gu.crossword
 
-import org.joda.time.{LocalDate}
-import java.util.{Map => JMap}
+import org.joda.time.LocalDate
 
+import java.util.{Map => JMap}
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.crossword.crosswords.models.CrosswordStatus
 import com.gu.crossword.crosswords.{APIChecker, CrosswordStore}

--- a/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/src/main/scala/com/gu/crossword/Lambda.scala
@@ -17,7 +17,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class Lambda
     extends RequestHandler[JMap[String, Object], String]
-    with APIChecker
     with CrosswordStore {
 
   override def handleRequest(
@@ -36,7 +35,7 @@ class Lambda
       val s3Status = checkCrosswordS3Status(crosswordId, crosswordType)
 
       val path = s"crosswords/$crosswordType/$crosswordId"
-      val apiStatus = checkIfCrosswordInApis(path)(config)
+      val apiStatus = APIChecker.checkIfCrosswordInApis(path)(config)
 
       val status =
         CrosswordStatus(s3Status, Await.result(apiStatus, 10 seconds))

--- a/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
@@ -1,15 +1,12 @@
 package com.gu.crossword.crosswords
 
 import java.io.IOException
-import java.net.URI
 
-import com.gu.contentapi.client.IAMSigner
 import com.gu.crossword.Config
 import com.gu.crossword.crosswords.models.{APIStatus, CrosswordApiLocations}
 import okhttp3._
 
 import scala.concurrent.{Future, Promise}
-import scala.jdk.CollectionConverters._
 
 object APIChecker {
 
@@ -65,27 +62,25 @@ object APIChecker {
       promise.future
     }
 
-    def buildRequest(reqUrl: String) = new Request.Builder().url(reqUrl).build
-
-    def buildReqWithAuth(reqUrl: String, signer: IAMSigner) =
-      new Request.Builder()
-        .url(reqUrl)
-        .headers {
-          val headers =
-            signer.addIAMHeaders(headers = Map.empty, uri = new URI(reqUrl))
-          Headers.of(headers.asJava)
-        }
-        .build
-
     val apiLocations = getApiLocations(path)(config)
 
-    val microappStatus = check200(buildRequest(apiLocations.microappUrl))
+    val builder = config.requestBuilder
 
-    val flexDraftStatus = check200(buildRequest(apiLocations.flexDraftUrl))
-    val flexLiveStatus = check200(buildRequest(apiLocations.flexLiveUrl))
-    val liveCapiStatus = check200(buildRequest(apiLocations.capiLiveUrl))
+    val microappStatus = check200(
+      builder.buildRequest(apiLocations.microappUrl, false)
+    )
+
+    val flexDraftStatus = check200(
+      builder.buildRequest(apiLocations.flexDraftUrl, false)
+    )
+    val flexLiveStatus = check200(
+      builder.buildRequest(apiLocations.flexLiveUrl, false)
+    )
+    val liveCapiStatus = check200(
+      builder.buildRequest(apiLocations.capiLiveUrl, false)
+    )
     val previewCapiStatus = check200(
-      buildReqWithAuth(apiLocations.capiPreviewUrl, config.signer)
+      builder.buildRequest(apiLocations.capiPreviewUrl, true)
     )
 
     for {

--- a/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
@@ -28,7 +28,7 @@ object APIChecker {
 
   def checkIfCrosswordInApis(
       path: String
-  )(config: Config): Future[APIStatus] = {
+  )(config: Config, builder: RequestBuilder): Future[APIStatus] = {
 
     import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -63,8 +63,6 @@ object APIChecker {
     }
 
     val apiLocations = getApiLocations(path)(config)
-
-    val builder = config.requestBuilder
 
     val microappStatus = check200(
       builder.buildRequest(apiLocations.microappUrl, false)

--- a/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
@@ -15,7 +15,9 @@ object APIChecker {
 
   private val http = new OkHttpClient()
 
-  def getApiLocations(path: String)(config: Config): CrosswordApiLocations = {
+  private def getApiLocations(
+      path: String
+  )(config: Config): CrosswordApiLocations = {
     val flexUrl = s"${config.flexUrl}${config.flexFindByPathEndpoint}"
     CrosswordApiLocations(
       s"${config.crosswordMicroAppUrl}/api/$path.json?api-key=${config.crosswordMicroAppKey}&show-unpublished=true",

--- a/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
@@ -20,11 +20,12 @@ object APIChecker {
   )(config: Config): CrosswordApiLocations = {
     val flexUrl = s"${config.flexUrl}${config.flexFindByPathEndpoint}"
     CrosswordApiLocations(
-      s"${config.crosswordMicroAppUrl}/api/$path.json?api-key=${config.crosswordMicroAppKey}&show-unpublished=true",
-      s"$flexUrl/$path/preview",
-      s"$flexUrl/$path/live",
-      s"${config.capiPreviewUrl}/$path",
-      s"${config.capiUrl}/$path?api-key=${config.capiKey}"
+      microappUrl =
+        s"${config.crosswordMicroAppUrl}/api/$path.json?api-key=${config.crosswordMicroAppKey}&show-unpublished=true",
+      flexDraftUrl = s"$flexUrl/$path/preview",
+      flexLiveUrl = s"$flexUrl/$path/live",
+      capiPreviewUrl = s"${config.capiPreviewUrl}/$path",
+      capiLiveUrl = s"${config.capiUrl}/$path?api-key=${config.capiKey}"
     )
   }
 
@@ -93,7 +94,13 @@ object APIChecker {
       fls <- flexLiveStatus
       pcs <- previewCapiStatus
       lcs <- liveCapiStatus
-    } yield APIStatus(ms, fds, fls, pcs, lcs)
+    } yield APIStatus(
+      inCrosswordMicroApp = ms,
+      inFlexDraftAPI = fds,
+      inFlexLiveApi = fls,
+      inCapiPreview = pcs,
+      inLiveCapi = lcs
+    )
   }
 
 }

--- a/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/APIChecker.scala
@@ -11,7 +11,7 @@ import okhttp3._
 import scala.concurrent.{Future, Promise}
 import scala.jdk.CollectionConverters._
 
-trait APIChecker {
+object APIChecker {
 
   private val http = new OkHttpClient()
 

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
@@ -7,7 +7,7 @@ import models._
 
 import scala.concurrent.Future
 
-object CrosswordDateChecker extends APIChecker {
+object CrosswordDateChecker {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -28,7 +28,8 @@ object CrosswordDateChecker extends APIChecker {
     val crosswordStatuses = CrosswordTypeHelpers.allTypes.flatMap { cw =>
       cw.getNo(date).map { no =>
         val path = s"crosswords/${cw.name}/$no"
-        val ready = checkIfCrosswordInApis(path)(config)
+        val ready = APIChecker
+          .checkIfCrosswordInApis(path)(config)
           .map(r => CrosswordReadyStatus(cw.name, no, r.inCapiPreview, date))
         ready
       }

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
@@ -42,17 +42,14 @@ object CrosswordDateChecker {
 
   def checkNextNDays(
       noDaysToCheck: Int
-  )(config: Config): Future[List[List[CrosswordReadyStatus]]] = {
+  )(
+      config: Config,
+      requestBuilder: RequestBuilder
+  ): Future[List[List[CrosswordReadyStatus]]] = {
     val daysToCheck = generateListOfNextNDays(noDaysToCheck)
     println(
       s"Checking the next $noDaysToCheck days for crosswords which aren't ready: ${daysToCheck.mkString(", ")}"
     )
-
-    val requestBuilder =
-      new RequestBuilderWithSigner(
-        config.capiPreviewRole,
-        Constants.awsRegion.toString
-      )
 
     // get statuses
     Future.sequence(

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
@@ -1,7 +1,7 @@
 package com.gu.crossword.crosswords
 
 import com.gu.crossword.Config
-import com.gu.crossword.services.SNS
+import com.gu.crossword.services.{Constants, SNS}
 import org.joda.time.{LocalDate, Period}
 import models._
 
@@ -25,11 +25,17 @@ object CrosswordDateChecker {
 
     println(s"Checking status of crosswords on $date")
 
+    val requestBuilder =
+      new RequestBuilderWithSigner(
+        config.capiPreviewRole,
+        Constants.awsRegion.toString
+      )
+
     val crosswordStatuses = CrosswordTypeHelpers.allTypes.flatMap { cw =>
       cw.getNo(date).map { no =>
         val path = s"crosswords/${cw.name}/$no"
         val ready = APIChecker
-          .checkIfCrosswordInApis(path)(config)
+          .checkIfCrosswordInApis(path)(config, requestBuilder)
           .map(r => CrosswordReadyStatus(cw.name, no, r.inCapiPreview, date))
         ready
       }

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordDateChecker.scala
@@ -21,15 +21,9 @@ object CrosswordDateChecker {
 
   def getAllCrosswordStatusesForDate(
       date: LocalDate
-  )(config: Config): Future[List[CrosswordReadyStatus]] = {
+  )(config: Config, requestBuilder: RequestBuilder): Future[List[CrosswordReadyStatus]] = {
 
     println(s"Checking status of crosswords on $date")
-
-    val requestBuilder =
-      new RequestBuilderWithSigner(
-        config.capiPreviewRole,
-        Constants.awsRegion.toString
-      )
 
     val crosswordStatuses = CrosswordTypeHelpers.allTypes.flatMap { cw =>
       cw.getNo(date).map { no =>
@@ -42,6 +36,8 @@ object CrosswordDateChecker {
     }
     Future.sequence(crosswordStatuses)
   }
+
+  def checkNextNDays(noDaysToCheck)
 
   def alertForBadCrosswords(
       statuses: List[CrosswordReadyStatus]

--- a/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -1,9 +1,8 @@
 package com.gu.crossword.crosswords
 
 import com.gu.crossword.Config
-import com.gu.crossword.services.S3.getS3Client
+import com.gu.crossword.services.S3
 
-import org.joda.time.{LocalDate}
 import scala.jdk.CollectionConverters._
 
 trait CrosswordStore {
@@ -25,7 +24,7 @@ trait CrosswordStore {
       format: String
   )(config: Config): List[String] = {
     if (id.isDefined) {
-      val files = config.s3Client
+      val files = S3.client
         .listObjects(bucketName, s"${id.get}.$format")
         .getObjectSummaries
         .asScala

--- a/src/main/scala/com/gu/crossword/crosswords/RequestBuilder.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/RequestBuilder.scala
@@ -1,3 +1,37 @@
-package com.gu.crossword.crosswords trait RequestBuilder {
+package com.gu.crossword.crosswords
 
+import com.gu.contentapi.client.IAMSigner
+import okhttp3.{Headers, Request}
+
+import java.net.URI
+import scala.jdk.CollectionConverters._
+
+trait RequestBuilder {
+  val builder: Request.Builder
+
+  def buildRequest(url: String, withAuth: Boolean): Request
+}
+
+class RequestBuilderWithSigner(signer: IAMSigner) extends RequestBuilder {
+  val builder = new Request.Builder()
+
+  def buildRequest(url: String, withAuth: Boolean) = {
+    val req = builder
+      .url(url)
+
+    if (withAuth) {
+      val headers =
+        signer.addIAMHeaders(headers = Map.empty, uri = new URI(url))
+      req.headers {
+        Headers.of(headers.asJava)
+      }
+    }
+    req.build
+  }
+}
+
+class BasicRequestBuilder extends RequestBuilder {
+  val builder = new Request.Builder()
+
+  def buildRequest(url: String, withAuth: Boolean) = builder.url(url).build
 }

--- a/src/main/scala/com/gu/crossword/crosswords/RequestBuilder.scala
+++ b/src/main/scala/com/gu/crossword/crosswords/RequestBuilder.scala
@@ -1,0 +1,3 @@
+package com.gu.crossword.crosswords trait RequestBuilder {
+
+}

--- a/src/main/scala/com/gu/crossword/services/Constants.scala
+++ b/src/main/scala/com/gu/crossword/services/Constants.scala
@@ -1,0 +1,8 @@
+package com.gu.crossword.services
+
+import com.amazonaws.regions.Regions
+
+object Constants {
+  val awsRegion = Regions.EU_WEST_1
+  val profile = "composer"
+}

--- a/src/main/scala/com/gu/crossword/services/CredentialsProvider.scala
+++ b/src/main/scala/com/gu/crossword/services/CredentialsProvider.scala
@@ -1,0 +1,14 @@
+package com.gu.crossword.services
+
+import com.amazonaws.auth.{
+  AWSCredentialsProviderChain,
+  DefaultAWSCredentialsProviderChain
+}
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+
+object CredentialsProvider {
+  val awsCredentialsProvider = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider(Constants.profile),
+    new DefaultAWSCredentialsProviderChain
+  )
+}

--- a/src/main/scala/com/gu/crossword/services/S3.scala
+++ b/src/main/scala/com/gu/crossword/services/S3.scala
@@ -4,12 +4,10 @@ import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 
 object S3 {
-  def getS3Client(
-      credentialsProviderChain: AWSCredentialsProviderChain
-  ): AmazonS3 =
+  def client: AmazonS3 =
     AmazonS3ClientBuilder
       .standard()
-      .withCredentials(credentialsProviderChain)
+      .withCredentials(CredentialsProvider.awsCredentialsProvider)
       .build()
 
 }

--- a/src/main/scala/com/gu/crossword/services/SNS.scala
+++ b/src/main/scala/com/gu/crossword/services/SNS.scala
@@ -6,17 +6,12 @@ import com.amazonaws.services.sns.model.PublishRequest
 import com.gu.crossword.Config
 
 object SNS {
-  def getSNSClient(
-      credentialsProviderChain: AWSCredentialsProviderChain,
-      region: String
-  ) = {
-    val client = AmazonSNSClientBuilder
-      .standard()
-      .withRegion(region)
-      .withCredentials(credentialsProviderChain)
-      .build()
-    client
-  }
+
+  private def client = AmazonSNSClientBuilder
+    .standard()
+    .withRegion(Constants.awsRegion)
+    .withCredentials(CredentialsProvider.awsCredentialsProvider)
+    .build()
 
   def publishMessage(message: String)(config: Config) = {
 
@@ -24,7 +19,7 @@ object SNS {
       new PublishRequest(config.alertTopic, message, "Crossword not ready")
 
     try {
-      config.snsClient.publish(publishRequest)
+      client.publish(publishRequest)
     } catch {
       case e: Exception =>
         println(s"SNS publishing failed with error: ${e.getMessage}")

--- a/src/test/scala/com/gu/crossword/crosswords/APICheckerTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/APICheckerTest.scala
@@ -1,3 +1,131 @@
-package com.gu.crossword.crosswords class APICheckerTest {
+package com.gu.crossword.crosswords
+
+import com.gu.crossword.Config
+import com.gu.crossword.crosswords.models.APIStatus
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+import okhttp3.mockwebserver.{
+  MockResponse,
+  MockWebServer,
+  RecordedRequest,
+  Dispatcher
+}
+
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+class APICheckerTest extends AnyFlatSpec with Matchers {
+
+  val emptyConfig = Config(
+    forProcessingBucketName = "",
+    processedBucketName = "",
+    processedPdfBucketName = "",
+    crosswordMicroAppUrl = "",
+    crosswordMicroAppKey = "",
+    capiUrl = "",
+    capiKey = "",
+    capiPreviewUrl = "",
+    capiPreviewRole = "",
+    flexUrl = "",
+    flexFindByPathEndpoint = "",
+    composerApiUrl = "",
+    composerFindByPathEndpoint = "",
+    alertTopic = ""
+  )
+
+  it should "return passing statuses if API calls return 200s" in {
+    val requestBuilder = new BasicRequestBuilder()
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+    val baseUrl = mockHttpServer.url("").toString
+    val config = emptyConfig.copy(
+      crosswordMicroAppUrl = baseUrl,
+      capiUrl = baseUrl,
+      capiPreviewUrl = baseUrl,
+      flexUrl = baseUrl,
+      flexFindByPathEndpoint = baseUrl,
+      composerApiUrl = baseUrl,
+      composerFindByPathEndpoint = baseUrl
+    )
+
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(200))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(200))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(200))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(200))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(200))
+
+    val statuses =
+      APIChecker.checkIfCrosswordInApis("quick/1")(config, requestBuilder)
+    Await.result(statuses, 1.seconds) mustBe APIStatus(
+      true, true, true, true, true
+    )
+
+  }
+
+  it should "return failing statuses if API calls return non-200s" in {
+    val requestBuilder = new BasicRequestBuilder()
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+    val baseUrl = mockHttpServer.url("").toString
+    val config = emptyConfig.copy(
+      crosswordMicroAppUrl = baseUrl,
+      capiUrl = baseUrl,
+      capiPreviewUrl = baseUrl,
+      flexUrl = baseUrl,
+      flexFindByPathEndpoint = baseUrl,
+      composerApiUrl = baseUrl,
+      composerFindByPathEndpoint = baseUrl
+    )
+
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(400))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(300))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(404))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(500))
+    mockHttpServer.enqueue(new MockResponse().setResponseCode(501))
+
+    val statuses =
+      APIChecker.checkIfCrosswordInApis("quick/1")(config, requestBuilder)
+    Await
+      .result(statuses, 1.seconds) mustBe APIStatus(
+      false, false, false, false, false
+    )
+  }
+
+  it should "return mixed statuses depending on API responses" in {
+    val requestBuilder = new BasicRequestBuilder()
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+    val baseUrl = mockHttpServer.url("").toString
+    val config = emptyConfig.copy(
+      crosswordMicroAppUrl = baseUrl,
+      crosswordMicroAppKey = "MICROAPP_REQUEST_IDENTIFIER",
+      capiUrl = baseUrl,
+      capiPreviewUrl = baseUrl,
+      flexUrl = baseUrl,
+      flexFindByPathEndpoint = baseUrl,
+      composerApiUrl = baseUrl,
+      composerFindByPathEndpoint = baseUrl
+    )
+
+    val dispatcher = new Dispatcher() {
+      def dispatch(request: RecordedRequest): MockResponse = {
+        request.getPath match {
+          case path if path.contains("MICROAPP_REQUEST_IDENTIFIER") =>
+            new MockResponse().setResponseCode(200)
+          case _ =>
+            new MockResponse().setResponseCode(300)
+        }
+      }
+    }
+    mockHttpServer.setDispatcher(dispatcher)
+
+    val statuses =
+      APIChecker.checkIfCrosswordInApis("quick/1")(config, requestBuilder)
+    Await
+      .result(statuses, 1.seconds) mustBe APIStatus(
+      true, false, false, false, false
+    )
+
+  }
 
 }

--- a/src/test/scala/com/gu/crossword/crosswords/APICheckerTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/APICheckerTest.scala
@@ -1,0 +1,3 @@
+package com.gu.crossword.crosswords class APICheckerTest {
+
+}

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
@@ -118,4 +118,6 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
 
   }
 
+
+
 }

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
@@ -123,6 +123,7 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
   behavior of "checkNextNDays"
 
   it should "return a list for each of the N days requested" in {
+    val requestBuilder = new BasicRequestBuilder()
     val mockHttpServer = new MockWebServer()
     mockHttpServer.start()
     val baseUrl = mockHttpServer.url("").toString
@@ -145,24 +146,25 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
 
     val one_days_statuses = CrosswordDateChecker.checkNextNDays(
       1
-    )(config)
+    )(config, requestBuilder)
 
     Await.result(one_days_statuses, 10.seconds).size mustBe 1
 
     val three_days_statuses = CrosswordDateChecker.checkNextNDays(
       3
-    )(config)
+    )(config, requestBuilder)
 
     Await.result(three_days_statuses, 10.seconds).size mustBe 3
 
     val nine_days_statuses = CrosswordDateChecker.checkNextNDays(
       9
-    )(config)
+    )(config, requestBuilder)
 
     Await.result(nine_days_statuses, 10.seconds).size mustBe 9
   }
 
   it should "return passing statuses if CAPI preview returns 200" in {
+    val requestBuilder = new BasicRequestBuilder()
     val mockHttpServer = new MockWebServer()
     mockHttpServer.start()
     val baseUrl = mockHttpServer.url("").toString
@@ -185,7 +187,7 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
 
     val statuses = CrosswordDateChecker.checkNextNDays(
       3
-    )(config)
+    )(config, requestBuilder)
 
     Await.result(statuses, 10.seconds) mustBe List(
       List(
@@ -231,6 +233,7 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
   }
 
   it should "return failing statuses if CAPI preview returns a non-200 response" in {
+    val requestBuilder = new BasicRequestBuilder()
     val mockHttpServer = new MockWebServer()
     mockHttpServer.start()
     val baseUrl = mockHttpServer.url("").toString
@@ -263,7 +266,7 @@ class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
 
     val statuses = CrosswordDateChecker.checkNextNDays(
       2
-    )(config)
+    )(config, requestBuilder)
 
     Await.result(statuses, 10.seconds) mustBe List(
       List(

--- a/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
+++ b/src/test/scala/com/gu/crossword/crosswords/CrosswordDateCheckerTest.scala
@@ -1,0 +1,121 @@
+package com.gu.crossword.crosswords
+
+import com.gu.crossword.Config
+import com.gu.crossword.crosswords.models.CrosswordReadyStatus
+import okhttp3.mockwebserver.{
+  Dispatcher,
+  MockResponse,
+  MockWebServer,
+  RecordedRequest
+}
+import org.joda.time.LocalDate
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class CrosswordDateCheckerTest extends AnyFlatSpec with Matchers {
+
+  val emptyConfig = Config(
+    forProcessingBucketName = "",
+    processedBucketName = "",
+    processedPdfBucketName = "",
+    crosswordMicroAppUrl = "",
+    crosswordMicroAppKey = "",
+    capiUrl = "",
+    capiKey = "",
+    capiPreviewUrl = "",
+    capiPreviewRole = "",
+    flexUrl = "",
+    flexFindByPathEndpoint = "",
+    composerApiUrl = "",
+    composerFindByPathEndpoint = "",
+    alertTopic = ""
+  )
+
+  it should "return passing statuses if CAPI Preview calls return 200s" in {
+    val requestBuilder = new BasicRequestBuilder()
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+    val baseUrl = mockHttpServer.url("").toString
+
+    val capiPreviewIdentifier = "CAPI_PREVIEW_REQUEST_IDENTIFIER"
+
+    val config = emptyConfig.copy(
+      crosswordMicroAppUrl = baseUrl,
+      capiUrl = baseUrl,
+      capiPreviewUrl = s"$baseUrl/$capiPreviewIdentifier",
+      flexUrl = baseUrl,
+      flexFindByPathEndpoint = baseUrl,
+      composerApiUrl = baseUrl,
+      composerFindByPathEndpoint = baseUrl
+    )
+
+    val dispatcher = new Dispatcher() {
+      def dispatch(request: RecordedRequest): MockResponse = {
+        request.getPath match {
+          case path if path.contains(capiPreviewIdentifier) =>
+            new MockResponse().setResponseCode(200)
+          case _ =>
+            new MockResponse().setResponseCode(300)
+        }
+      }
+    }
+    mockHttpServer.setDispatcher(dispatcher)
+
+    val statuses = CrosswordDateChecker.getAllCrosswordStatusesForDate(
+      new LocalDate(2023, 9, 27)
+    )(config, requestBuilder)
+
+    Await.result(statuses, 10.seconds) mustBe List(
+      CrosswordReadyStatus("quick", 16659, true, new LocalDate("2023-09-27")),
+      CrosswordReadyStatus("cryptic", 29186, true, new LocalDate("2023-09-27"))
+    )
+
+  }
+
+  it should "return failing statuses for any CAPI Preview calls that return not-200s" in {
+    val requestBuilder = new BasicRequestBuilder()
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+    val baseUrl = mockHttpServer.url("").toString
+
+    val capiPreviewIdentifier = "CAPI_PREVIEW_REQUEST_IDENTIFIER"
+
+    val config = emptyConfig.copy(
+      crosswordMicroAppUrl = baseUrl,
+      capiUrl = baseUrl,
+      capiPreviewUrl = s"$baseUrl/$capiPreviewIdentifier",
+      flexUrl = baseUrl,
+      flexFindByPathEndpoint = baseUrl,
+      composerApiUrl = baseUrl,
+      composerFindByPathEndpoint = baseUrl
+    )
+
+    val dispatcher = new Dispatcher() {
+      def dispatch(request: RecordedRequest): MockResponse = {
+        request.getPath match {
+          case path
+              if path
+                .contains(capiPreviewIdentifier) && path.contains("quick") =>
+            new MockResponse().setResponseCode(200)
+          case _ =>
+            new MockResponse().setResponseCode(404)
+        }
+      }
+    }
+    mockHttpServer.setDispatcher(dispatcher)
+
+    val statuses = CrosswordDateChecker.getAllCrosswordStatusesForDate(
+      new LocalDate(2023, 9, 27)
+    )(config, requestBuilder)
+
+    Await.result(statuses, 10.seconds) mustBe List(
+      CrosswordReadyStatus("quick", 16659, true, new LocalDate("2023-09-27")),
+      CrosswordReadyStatus("cryptic", 29186, false, new LocalDate("2023-09-27"))
+    )
+
+  }
+
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The aim of this PR is to make the minimum changes necessary in order to add testing to the two key API checking methods: `checkIfCrosswordInApis` and `getAllCrosswordStatusesForDate` (which calls the former).

If these changes are accepted, I have some follow-up changes that I'd like to make, to simplify testing.

Changes:

- The `Config` class needed to be refactored, so that it could be mocked without having to mock the AWS clients and `IAMSigner` that were referenced in it before. I've pulled out the AWS clients into the existing `services` package, and converted `Config` to a case class, so that it can be easily mocked for testing, using static data.
- Create a `RequestBuilder` trait and convert the API checking methods to have a request builder passed in as a parameter. In production the request builder needs to have access to an `IAMSigner`, which is not necessary for testing the business logic of the checkers, and is difficult to mock. So I've added a `BasicRequestBuilder` object which can be used for testing, which doesn't require a signer.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run the unit tests
- [ ] If anyone has good ideas about how to test in prod, or generate new test cases, please let me know!

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Better test coverage should make it easier to make subsequent changes.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

