### PR TITLE
Add deprecation note and redirect link to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-crossword-status-checker
+crossword-status-checker (deprecated)
 ========================
+
+>**Note**
+>This service has now been deprecated. Its functionality has been moved to the
+> [crosswordv2](https://github.com/guardian/crosswordv2) project.
 
 This is a Lambda function designed to make it easier to see what's gone wrong with a particular crossword. 
 It checks S3 buckets, the crossword API, CAPI and Flexible content for a crossword.

--- a/public/status-check.html
+++ b/public/status-check.html
@@ -9,6 +9,19 @@
 <body>
 
 <h1>Crossword Status Checker</h1>
+
+<section class="admin-message">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+    </svg>
+    <div>
+        <h2>Service moved</h2>
+        <p>This service has been deprecated and will be removed from this URL soon.</p>
+        <p>Please use <a href="https://crosswordv2.gutools.co.uk">https://crosswordv2.gutools.co.uk</a> instead.</p>
+        <p>The new status checker page requires Google authentication, but can be accessed outside of the office network. If you have any issues with the new site, please contact the Newsroom Resilience team at: newsroom.resilience@guardian.co.uk.</p>
+    </div>
+</section>
+
 <p>This app should help you determine what's gone wrong (if anything) with a crossword. Pre-publication, a crossword
 is 'ready' if it is in CAPI Preview. After publication, it should also be visible in CAPI live. If it gets lost somewhere
 along the way and doesn't make it into CAPI, the information below should be useful for troubleshooting.</p>

--- a/public/style.css
+++ b/public/style.css
@@ -1,3 +1,11 @@
+:root {
+    --sp-small: 6px;
+    --sp-base: 8px;
+    --sp-large: 16px;
+    --color-warning: hsl(346, 86%, 53%);
+    --color-warning-light: hsl(346, 65%, 90%);
+}
+
 body {
     max-width: 1000px;
     margin: 0 auto;
@@ -8,4 +16,33 @@ body {
     max-width: 100%;
     height: auto;
     display:block;
+}
+
+.admin-message {
+    padding: var(--sp-large) var(--sp-base) var(--sp-base) var(--sp-base);
+    border: 2px solid var(--color-warning);
+    display: flex;
+    gap: 1rem;
+    background-color: var(--color-warning-light);
+    margin: var(--sp-large) 0;
+}
+
+.admin-message p {
+    white-space: pre-wrap;
+    line-height: 1.3;
+    overflow-wrap: break-word;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding-bottom: var(--sp-small);
+}
+
+.admin-message h2 {
+    font-size: 1.5rem;
+    padding-bottom: var(--sp-base);
+    margin: 0;
+}
+
+.admin-message svg {
+    width: 3rem;
+    height: 3rem;
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a deprecation note and redirect link to the status checker UI, pointing towards the [new status checker implementation](https://crosswordv2.gutools.co.uk)
- Add a deprecation note to this repo's README.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Open the `status-checker.html` file locally, or deploy and check it remotely (requires VPN).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We're sending out comms about the switch-over. Hopefully this will help people who miss those comms, or who are following an old link, to find the new one.
## Images

<img width="852" alt="image" src="https://github.com/guardian/crossword-status-checker/assets/37048459/9f503117-8c03-403f-94e6-657b9d68b798">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
